### PR TITLE
Added consistant function names for BFS and DFS

### DIFF
--- a/pygorithm/searching/breadth_first_search.py
+++ b/pygorithm/searching/breadth_first_search.py
@@ -2,7 +2,7 @@
 # Created On: 1st August 2017
 
 #  breadth first search algorithm
-def bfs(graph, startVertex):
+def search(graph, startVertex):
     # Take a list for stoting already visited vertexes
     if startVertex not in graph or graph[startVertex] is None or graph[startVertex] == []:
         return None
@@ -25,4 +25,4 @@ def time_complexities():
 # easily retrieve the source code of the bfs function
 def get_code():
     import inspect
-    return inspect.getsource(bfs)
+    return inspect.getsource(search)

--- a/pygorithm/searching/depth_first_search.py
+++ b/pygorithm/searching/depth_first_search.py
@@ -2,7 +2,7 @@
 # Created On: 1st August 2017
 
 #  depth first search algorithm
-def dfs(graph, start, path = []):
+def search(graph, start, path = []):
     # check if graph is empty or start vertex is none
     if start not in graph or graph[start] is None or graph[start] == []:
         return None
@@ -19,4 +19,4 @@ def time_complexities():
 # easily retrieve the source code of the dfs function
 def get_code():
     import inspect
-    return inspect.getsource(dfs)
+    return inspect.getsource(search)

--- a/tests/searching_tests.py
+++ b/tests/searching_tests.py
@@ -47,9 +47,9 @@ class BFSSearch(unittest.TestCase):
             'E': {'A'},
             'G': {'C'}
         }
-        result = breadth_first_search.bfs(self.graph, 'A')
+        result = breadth_first_search.search(self.graph, 'A')
         self.assertEqual(result, {'A', 'B', 'D', 'F', 'C', 'G', 'E'})
-        result = breadth_first_search.bfs(self.graph, 'G')
+        result = breadth_first_search.search(self.graph, 'G')
         self.assertEqual(result, {'G', 'C', 'A', 'B', 'D', 'F', 'E'})
 
 class DFSSearch(unittest.TestCase):
@@ -63,9 +63,9 @@ class DFSSearch(unittest.TestCase):
             'E': ['A'],
             'G': ['C']
         }
-        result = depth_first_search.dfs(self.graph, 'A')
+        result = depth_first_search.search(self.graph, 'A')
         self.assertEqual(result, ['A', 'B', 'D', 'F', 'C', 'G', 'E'])
-        result = depth_first_search.dfs(self.graph, 'G')
+        result = depth_first_search.search(self.graph, 'G')
         self.assertEqual(result, ['G', 'C', 'A', 'B', 'D', 'F', 'E'])
 
 if __name__ == '__main__':


### PR DESCRIPTION
The other search algorithms (Binary Search and Linear Search) search function is simply called `search`. Breadth First Search (BFS) and Depth First Search (DFS) have the inconsistent names `bfs` and `dfs` respectively. I motion that these names are changed in favour of the simpler `search`.

It will not only make it easier for users (they won't have to look up every single search function's name), but also help easy development.