### PR TITLE
Update documentation to not recomend sudo with pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Installation
    pip3 install pygorithm
 
 - | It's that easy. If you are using Python 2.7 use pip instead. Depending on your
-  | permissions, you might need to ``sudo`` before installing
+  | permissions, you might need to use ``pip install --user pygorithm`` to install.
 
 
 Quick Start Guide


### PR DESCRIPTION
This answers https://github.com/OmkarPathak/pygorithm/issues/3. Documentation should forgo bad practice when ever possible and using pip with `sudo` is bad practice.