### PR TITLE
Add function that returns a list of all functions in their respective category

### DIFF
--- a/pygorithm/data_structures/__init__.py
+++ b/pygorithm/data_structures/__init__.py
@@ -1,0 +1,1 @@
+from . modules import modules

--- a/pygorithm/data_structures/modules.py
+++ b/pygorithm/data_structures/modules.py
@@ -1,0 +1,14 @@
+import pkgutil
+def modules():
+    """
+    Find all functions in pygorithm.data_structures
+    """
+    import pygorithm.data_structures
+    package = pygorithm.data_structures
+    modules = []
+    for importer, modname, ispkg in pkgutil.iter_modules(package.__path__):
+        modules.append(modname)
+    modules.remove('modules')
+    modules.sort()
+    return modules
+

--- a/pygorithm/searching/__init__.py
+++ b/pygorithm/searching/__init__.py
@@ -1,0 +1,1 @@
+from . modules import modules

--- a/pygorithm/searching/modules.py
+++ b/pygorithm/searching/modules.py
@@ -1,0 +1,14 @@
+import pkgutil
+def modules():
+    """
+    Find all functions in pygorithm.searching
+    """
+    import pygorithm.searching
+    package = pygorithm.searching
+    modules = []
+    for importer, modname, ispkg in pkgutil.iter_modules(package.__path__):
+        modules.append(modname)
+    modules.remove('modules')
+    modules.sort()
+    return modules
+

--- a/pygorithm/sorting/modules.py
+++ b/pygorithm/sorting/modules.py
@@ -1,0 +1,14 @@
+import pkgutil
+def modules():
+    """
+    Find all functions in pygorithm.sorting
+    """
+    import pygorithm.sorting
+    package = pygorithm.sorting
+    modules = []
+    for importer, modname, ispkg in pkgutil.iter_modules(package.__path__):
+        modules.append(modname)
+    modules.remove('modules')
+    modules.sort()
+    return modules
+


### PR DESCRIPTION
This is a resubmission of the [previous pull request](https://github.com/OmkarPathak/pygorithm/pull/9). Here is the description:

This new function in `pygorithm.sorting` and `pygorithm.search` returns a list of all functions in `pygorithm.sorting` and  `pygorithm.search`.

Example usage:

```
>>> from pygorithm.sorting import modules
>>> modules()
['bubble_sort', 'bucket_sort', 'counting_sort', 'heap_sort', 'insertion_sort', 'merge_sort', 'quick_sort', 'selection_sort', 'shell_sort']
```

This will make it easier for users to see what functions are available to them without looking at the entire source code or documentation.