### PR TITLE
Fixed worst case for shell sort

### DIFF
--- a/pygorithm/sorting/shell_sort.py
+++ b/pygorithm/sorting/shell_sort.py
@@ -20,7 +20,7 @@ def sort(List):
 
 # time complexities
 def time_complexities():
-    return '''Best Case: O(nlogn), Average Case: O(depends on gap sequence), Worst Case: O(n)'''
+    return '''Best Case: O(nlogn), Average Case: O(depends on gap sequence), Worst Case: O(n ^ 2)'''
 
 # easily retrieve the source code of the sort function
 def get_code():


### PR DESCRIPTION
Hi, 

The worst case performance of shell sort is O(n ^ 2) when using a non-optimal gap sequence. 
O(n log^2(n)) when using an optimized gap sequence. 

Not O(n) as stated in the code. 