### PR TITLE
Add BiDirectional AStar

### DIFF
--- a/docs/Pathfinding.rst
+++ b/docs/Pathfinding.rst
@@ -41,6 +41,7 @@ Features
 * Algorithms available:
     - Dijkstra (dijkstra)
     - Unidirectional AStar (astar)
+    - BiDirectional AStar (astar)
 
 
 * To see all the available functions in a module there is a `modules()` function available. For example,
@@ -82,6 +83,19 @@ Unidirectional AStar
 * Functions and their uses
 
 .. function:: astar.OneDirectionalAStar.find_path(pygorithm.data_structures.WeightedUndirectedGraph, vertex, vertex, function)
+
+- **pygorithm.data_structures.WeightedUndirectedGraph** : acts like an object with `graph` and `get_edge_weight` (see WeightedUndirectedGraph)
+- **vertex** : any hashable type for the start of the path
+- **vertex** : any hashable type for the end of the path
+- **function** : `function(graph, vertex, vertex)` returns numeric - a heuristic function for distance between two vertices
+- **Return Value** : returns a `List` of vertexes (of the same type of the graph) starting from from and going to to. This algorithm respects weights, but is only guarranteed to be optimal if the heuristic is admissable. An admissable function will never *overestimate* the cost from one node to another (in other words, it is optimistic).
+
+BiDirectional AStar
+-------------------
+
+* Functions and their uses
+
+.. function:: astar.BiDirectionalAStar.find_path(pygorithm.data_structures.WeightedUndirectedGraph, vertex, vertex, function)
 
 - **pygorithm.data_structures.WeightedUndirectedGraph** : acts like an object with `graph` and `get_edge_weight` (see WeightedUndirectedGraph)
 - **vertex** : any hashable type for the start of the path

--- a/tests/test_pathing.py
+++ b/tests/test_pathing.py
@@ -58,4 +58,14 @@ class TestAStarUnidirectionalTimed(SimplePathfindingTestCaseTimed):
             return math.sqrt(dx * dx + dy * dy)
         
         return my_pathfinder.find_path(my_graph, v1, v2, my_heuristic)
-    
+
+class TestAStarBiDirectionalTimed(SimplePathfindingTestCaseTimed):
+    def find_path(self, my_graph, v1, v2):
+        my_pathfinder = astar.BiDirectionalAStar()
+        
+        def my_heuristic(graph, v1, v2):
+            dx = v2[0] - v1[0]
+            dy = v2[1] - v1[1]
+            return math.sqrt(dx * dx + dy * dy)
+        
+        return my_pathfinder.find_path(my_graph, v1, v2, my_heuristic)


### PR DESCRIPTION
I switched to using asserts rather than exceptions for things that should
be impossible, since exceptions should at least be partly caused by the
parameters

* docs/Pathfinding.rst - Add BiDirectionalAStar. Functions identically to
onedirectional astar, as the differences are solely in performance
characteristics

* pygorithm/pathfinding/astar.py - Minor documentation tweaks for
consistency and improve performance of reversing the list for one
directonal astar (avoid shifting elements so much). Fix referencing the
loop variable 'i' instead of 'found' and remove related TODO

Add BiDirectionalAStar. I think there is some room to reduce the length

* tests/test_pathing.py - Add the basic test (passing)