### PR TITLE
docs: fix simple typo, wierd -> weird

### DIFF
--- a/imgs/test_geometry/test_extrapolated_intersection/utils.py
+++ b/imgs/test_geometry/test_extrapolated_intersection/utils.py
@@ -27,7 +27,7 @@ def prepare_figure(fig, ax, title, xlim, ylim):
     ax.xaxis.set_ticks(range(xlim[0]+1, xlim[1]))
     ax.yaxis.set_ticks(range(ylim[0]+1, ylim[1]))
     
-    # force reasonable aspect ratio (default is scaled wierd)
+    # force reasonable aspect ratio (default is scaled weird)
     ax.set_aspect('equal')
     
     # remove outer spines (clutter) and move left and bottom spines to 0 (instead of xmin and ymin)


### PR DESCRIPTION
There is a small typo in imgs/test_geometry/test_extrapolated_intersection/utils.py.

Should read `weird` rather than `wierd`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md